### PR TITLE
Unify names

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ sudo make install
 
 ### AUR
 ```
-yay -S center-algn
+yay -S center-align
 ```
 [AUR](https://aur.archlinux.org/packages/center-align)
 

--- a/Readme.md
+++ b/Readme.md
@@ -10,8 +10,8 @@ flags:
     -a, --all: will center every line individually (Horizontal center)
 
 usage:
-    command | center
-    command | center -a
+    command | center-align
+    command | center-align -a
 ```
 
 ## Installation

--- a/center
+++ b/center
@@ -67,8 +67,8 @@ flags:
     -a, --all: will center every line individually (Horizontal center)
 
 usage:
-    command | center
-    command | center -a
+    command | center-align
+    command | center-align -a
 
 EOF
 }


### PR DESCRIPTION
Some examples call the program 'center' and some call it 'center-align'.

These changes make all examples use 'center-align'.