### PR TITLE
make upper_padding minimum of 1

### DIFF
--- a/center
+++ b/center
@@ -35,7 +35,8 @@ main() {
 		left_padding=$(((totalhLen - hlen) / 2))
 	}
 	upper_padding=$(((totalvLen - vlen) / 2))
-
+	# if upper padding is negative, sed gets confused
+	[ "$upper_padding" -lt 1 ] && upper_padding=1
 	yes '' | sed "$upper_padding"q
 	for i in "${content[@]}"; do
 		$all && {


### PR DESCRIPTION
Try 

> fortune | figlet | ./center

and you'll find errors when the text is too high, which means that the `$upper_padding` variable is less than 1, which then makes sed confused about what it's doing.

This fixes the problem, though I suspect there's a better way to fix this problem.