### PR TITLE
Some optimisations

### DIFF
--- a/center
+++ b/center
@@ -6,7 +6,7 @@
 main() {
 	all=false
 	# ArgumentParser
-	while [ $# -gt 0 ]; do
+	while (( $# > 0 )); do
 		case "$1" in
 		-h | --help)
 			help
@@ -30,36 +30,33 @@ main() {
 		content+=("$line")
 	done
 
-	totalvLen=$(tput lines)
-	totalhLen=$(tput cols)
-	vlen=${#content[@]}
-	$all || {
-		hlen=$(getMaxlen "${content[@]}")
-		left_padding=$(((totalhLen - hlen) / 2))
-	}
-	upper_padding=$(((totalvLen - vlen) / 2))
-	# if upper padding is negative, sed gets confused
-	[ "$upper_padding" -lt 1 ] && upper_padding=1
-	yes '' 2>/dev/null | sed "$upper_padding"q
-	for i in "${content[@]}"; do
-		$all && {
-			hlen="${#i}"
-			left_padding=$(((totalhLen - hlen) / 2))
-		}
-		printf " %.0s" $(seq 1 "$left_padding")
-		printf "%s\n" "$i"
-	done
-	yes '' 2>/dev/null | sed "$upper_padding"q
+	# Call "cat" to initialize $LINES and $COLUMNS
+	cat /dev/null
+	(( upper_padding = (LINES - ${#content[@]}) / 2 ))
+	(( upper_padding < 1 )) && upper_padding=0
 
+	printf -v upad '%*s' $upper_padding ''
+	printf '%b' "${upad// /\\n}"
+
+	if $all; then
+		for i in "${content[@]}"; do
+			printf "%*s\n" $(((COLUMNS + ${#i}) / 2)) "$i"
+		done
+	else
+		getMaxlen "${content[@]}"
+		printf -v lpad '%*s' $(((COLUMNS - max) / 2 )) ''
+		printf "$lpad%s\n" "${content[@]}"
+	fi
+
+	printf '%b' "${upad// /\\n}"
 }
+
 getMaxlen() {
-	local max=0
 	for i in "$@"; do
-		if [ ${#i} -gt "$max" ]; then
+		if (( ${#i} > max )); then
 			max=${#i}
 		fi
 	done
-	echo "$max"
 }
 
 help() {

--- a/center
+++ b/center
@@ -35,8 +35,8 @@ main() {
 	(( upper_padding = (LINES - ${#content[@]}) / 2 ))
 	(( upper_padding < 1 )) && upper_padding=0
 
-	printf -v upad '%*s' $upper_padding ''
-	printf '%b' "${upad// /\\n}"
+	printf -v upper_padding '%*s' $upper_padding ''
+	printf '%b' "${upper_padding// /\\n}"
 
 	if $all; then
 		for i in "${content[@]}"; do
@@ -44,11 +44,11 @@ main() {
 		done
 	else
 		getMaxlen "${content[@]}"
-		printf -v lpad '%*s' $(((COLUMNS - max) / 2 )) ''
-		printf "$lpad%s\n" "${content[@]}"
+		printf -v left_padding '%*s' $(((COLUMNS - max) / 2 )) ''
+		printf "$left_padding%s\n" "${content[@]}"
 	fi
 
-	printf '%b' "${upad// /\\n}"
+	printf '%b' "${upper_padding// /\\n}"
 }
 
 getMaxlen() {


### PR DESCRIPTION
Mostly getting rid of external commands in favour of `printf` and needles variable assignments

[hyperfine](https://github.com/sharkdp/hyperfine) benchmarks
| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `optimized < 20lines` | 5.7 ± 0.3 | 5.4 | 6.7 | 1.00 |
| `optimized -a < 20lines` | 5.8 ± 0.3 | 5.5 | 7.6 | 1.01 ± 0.06 |
| `optimized < 1000lines` | 28.1 ± 0.6 | 27.1 | 30.1 | 4.90 ± 0.25 |
| `optimized -a < 1000lines` | 29.1 ± 0.6 | 28.1 | 31.9 | 5.07 ± 0.26 |
| `original -a < 20lines` | 35.4 ± 0.5 | 34.0 | 37.0 | 6.16 ± 0.30 |
| `original < 20lines` | 35.9 ± 0.5 | 34.9 | 37.2 | 6.26 ± 0.30 |
| `original < 1000lines` | 1130.5 ± 8.0 | 1116.3 | 1141.5 | 197.06 ± 9.16 |
| `original -a < 1000lines` | 1139.7 ± 3.9 | 1135.3 | 1147.9 | 198.67 ± 9.15 |
